### PR TITLE
add meta google notranslate

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -22,6 +22,9 @@ export function generateStaticParams() {
 
 export const metadata: Metadata = {
   metadataBase: new URL(getBaseUrl()),
+  other: {
+    google: "notranslate",
+  },
 };
 
 export default async function LocaleLayout({ children, params }: LayoutProps) {


### PR DESCRIPTION
### Description

Add `<meta name="google" content="notranslate">` to prevent Google Translate. 

`locale-switcher.jsx` should do the job (through `next-intl`).