### PR TITLE
Rename external link/refact locale switcher

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 
 import Logo from "./logo";
-import ExternalLink from "./external-link";
+import NativeLink from "./native-link";
 
-import { type ExternalLinkProps } from "./external-link";
+import { type NativeLinkProps } from "./native-link";
 
 import { useTranslations, useMessages } from "next-intl";
 
@@ -15,9 +15,9 @@ function FooterParagraphs() {
       <p className={clsx("pr-2 text-sm", "lg:text-base")}>
         {t.rich("stackDesc", {
           repo: (chunks) => (
-            <ExternalLink href="https://github.com/14githubruno/my-portfolio">
+            <NativeLink href="https://github.com/14githubruno/my-portfolio">
               {chunks}
-            </ExternalLink>
+            </NativeLink>
           ),
         })}
       </p>
@@ -45,10 +45,10 @@ function Contacts() {
         "lg:gap-8"
       )}
     >
-      {contacts.map((contact: ExternalLinkProps) => {
+      {contacts.map((contact: NativeLinkProps) => {
         return (
           <li key={contact.text}>
-            <ExternalLink {...contact} />
+            <NativeLink {...contact} />
           </li>
         );
       })}

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -2,6 +2,7 @@
 
 import { useLocale } from "next-intl";
 import { usePathname as useNextIntlPathname } from "@/i18n/navigation";
+import NativeLink from "./native-link";
 
 export default function LocaleSwitcher() {
   const locale = useLocale();
@@ -9,11 +10,10 @@ export default function LocaleSwitcher() {
   const pathname = useNextIntlPathname();
 
   return (
-    <a
+    <NativeLink
       href={`${pathname}${otherLocale}`}
-      className="w-fit text-sm underline md:text-base"
-    >
-      {otherLocale}
-    </a>
+      target="_self"
+      text={otherLocale}
+    />
   );
 }

--- a/src/components/native-link.tsx
+++ b/src/components/native-link.tsx
@@ -1,19 +1,22 @@
 import clsx from "clsx";
 import { ReactNode } from "react";
 
-export type ExternalLinkProps = {
+export type NativeLinkProps = {
   href: string;
   target?: "_blank" | "_self";
   text?: string;
   children?: ReactNode;
 };
 
-export default function ExternalLink({
+/**
+ * @note This component will be used when Next.js <Link> component is not needed
+ */
+export default function NativeLink({
   href,
   target = "_blank",
   text,
   children,
-}: ExternalLinkProps) {
+}: NativeLinkProps) {
   if (!text && !children) return null;
   return (
     <a

--- a/src/components/sections/projects-section.tsx
+++ b/src/components/sections/projects-section.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import { useMessages } from "next-intl";
-import ExternalLink from "../external-link";
-import { type ExternalLinkProps } from "../external-link";
+import NativeLink from "../native-link";
+import { type NativeLinkProps } from "../native-link";
 
-type SingleProjectLinks = ExternalLinkProps[];
+type SingleProjectLinks = NativeLinkProps[];
 
 type SingleProjectProps = {
   title: string;
@@ -83,7 +83,7 @@ function SingleProject({ title, desc, stack, links }: SingleProjectProps) {
                   {link.text}
                 </span>
               ) : (
-                <ExternalLink {...link} />
+                <NativeLink {...link} />
               )}
             </li>
           );


### PR DESCRIPTION
### Description

- Rename `external-link.tsx` to `native-link.tsx`, since the latter is used for both external links and other links which do _not_ need Next.js `<Link>` component or to have a target equal to `"_blank"`

- Use `native-link.tsx` in `locale-switcher.tsx`